### PR TITLE
fixed typo

### DIFF
--- a/docs/react-three-fiber/getting-started/your-first-scene.mdx
+++ b/docs/react-three-fiber/getting-started/your-first-scene.mdx
@@ -100,7 +100,7 @@ Then, geometry and material are _attached_ to their parent.
 
 ### Constructor arguments
 
-If we consult the [documentation for THREE's `BoxGeometry`](https://threejs.org/docs/#api/en/geometries/BoxGeometry) we see can can optionally pass three arguments for: width, length and depth:
+If we consult the [documentation for THREE's `BoxGeometry`](https://threejs.org/docs/#api/en/geometries/BoxGeometry) we see it can optionally pass three arguments for: width, length and depth:
 
 ```js
 const geometry = new THREE.BoxGeometry(2, 2, 2)


### PR DESCRIPTION
fix typo in constructor arguments
we see can can optionally pass three arguments for: width, length and depth to we see it can optionally pass three arguments for: width, length, depth